### PR TITLE
fix: require explicit throwing of LuaState errors

### DIFF
--- a/src/main/java/net/hollowcube/luau/LuaState.java
+++ b/src/main/java/net/hollowcube/luau/LuaState.java
@@ -240,11 +240,12 @@ public sealed interface LuaState extends AutoCloseable permits LuaStateImpl {
     void setMemCat(int category);
     long totalBytes(int category);
 
-    /// Throws, assumes that there is a value on the stack which becomes the thrown object.
-    @Contract("-> fail")
+    /// Creates a LuaError for the caller to throw
+    @CheckReturnValue
     LuaError error();
+    @CheckReturnValue
     LuaError error(String message);
-    @Contract("_, _ -> fail")
+    @CheckReturnValue
     LuaError error(@PrintFormat String message, @Nullable Object... args);
     @Contract("_, _ -> fail")
     void typeError(int narg, String tname);

--- a/src/main/java/net/hollowcube/luau/LuaStateImpl.java
+++ b/src/main/java/net/hollowcube/luau/LuaStateImpl.java
@@ -844,7 +844,7 @@ record LuaStateImpl(MemorySegment L) implements LuaState {
 
     @Override
     public LuaError error() {
-        throw new LuaError(null);
+        return new LuaError(null);
     }
 
     @Override
@@ -994,7 +994,7 @@ record LuaStateImpl(MemorySegment L) implements LuaState {
     @Override
     public void checkAny(int argNum) {
         if (lua_type(L, argNum) == LuaType.NONE.id()) return;
-        error("missing argument #%d", argNum);
+        throw error("missing argument #%d", argNum);
     }
 
     @Override

--- a/src/main/java/net/hollowcube/luau/require/RequireImpl.java
+++ b/src/main/java/net/hollowcube/luau/require/RequireImpl.java
@@ -40,7 +40,7 @@ public final class RequireImpl {
 
     public static void registerModule(LuaState state, String path) {
         if (path.isEmpty() || path.charAt(0) != '@')
-            state.error("path must begin with '@'");
+            throw state.error("path must begin with '@'");
 
         state.findTable(REGISTRY_INDEX, REGISTERED_CACHE_TABLE_KEY, 1);
 
@@ -76,7 +76,7 @@ public final class RequireImpl {
             int level = 0;
             do {
                 if (lua_getinfo(state.L(), level++, DEBUG_WHAT, debug) == 0)
-                    state.error("require is not supported in this context");
+                    throw state.error("require is not supported in this context");
             } while (lua_Debug.what(debug).get(ValueLayout.JAVA_BYTE, 0) != 'L');
 
             final String source = lua_Debug.source(debug).getString(0);
@@ -90,7 +90,7 @@ public final class RequireImpl {
         final String cacheKey = state.checkString(2);
 
         if (numResults < 1)
-            state.error("module must return a single value");
+            throw state.error("module must return a single value");
 
         // Cache the results
         if (numResults == 1) {
@@ -117,7 +117,7 @@ public final class RequireImpl {
         state.top(1); // Discard extra arguments, we only use path
 
         final RequireResolver lrc = (RequireResolver) state.toUserData(upvalueIndex(1));
-        if (lrc == null) state.error("unable to find require configuration");
+        if (lrc == null) throw state.error("unable to find require configuration");
 
         final String path = state.checkString(1);
         if (checkRegisteredModules(state, path))
@@ -128,7 +128,7 @@ public final class RequireImpl {
             case ResolvedRequire.Cached _ -> {
                 return 1;
             }
-            case ResolvedRequire.ErrorReported(String error) -> state.error(error);
+            case ResolvedRequire.ErrorReported(String error) -> throw state.error(error);
             case ResolvedRequire.ModuleRead(String chunkName, String loadName, String cacheKey) -> {
                 // (1) path, ..., cacheKey, chunkname, loadname
                 state.pushString(cacheKey);
@@ -147,7 +147,7 @@ public final class RequireImpl {
         int numResults = lrc.load(state, path, chunkName, loadName);
         if (numResults == -1) {
             if (state.top() != stackValues)
-                state.error("stack cannot be modified when require yields");
+                throw state.error("stack cannot be modified when require yields");
             return state.yield(0);
         }
 
@@ -165,7 +165,7 @@ public final class RequireImpl {
 
     private static ResolvedRequire resolveRequire(RequireResolver lrc, LuaState state, String requirerChunkName, String path) {
         if (!lrc.isRequireAllowed(state, requirerChunkName))
-            state.error("require is not supported in this context");
+            throw state.error("require is not supported in this context");
 
         final Navigator navigator = new Navigator(lrc, state, requirerChunkName);
 

--- a/src/test/java/net/hollowcube/luau/TestLuaError.java
+++ b/src/test/java/net/hollowcube/luau/TestLuaError.java
@@ -24,7 +24,9 @@ public class TestLuaError {
 
     @Test
     void errorShouldThrowLuaError(LuaState state) {
-        assertThrows(LuaError.class, state::error);
+        assertThrows(LuaError.class, () -> {
+            throw state.error();
+        });
     }
 
     @Test
@@ -98,8 +100,7 @@ public class TestLuaError {
     void throwInUpcallNoMessage(LuaState state, Arena arena) {
         var func = LuaFunc.wrap(
             L -> {
-                L.error();
-                return 0;
+                throw L.error();
             },
             "errfunc",
             arena


### PR DESCRIPTION
~~The codebase seems to expect LuaState#error to be self throwing, but 3cf6eb6 changed two of the three to return instead of throw.~~

After tinkering a bit more and running into other issues, it definitely seems more appropriate to go the opposite direction and make callers throw instead